### PR TITLE
Add dirs-1.0.3 (to replace std::env::home_dir)

### DIFF
--- a/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/Cargo.toml
+++ b/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name        = "dirs"
+version     = "1.0.3"
+authors     = ["Simon Ochsenreither <simon@ochsenreither.de>"]
+description = "A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS."
+readme      = "README.md"
+license     = "MIT OR Apache-2.0"
+repository  = "https://github.com/soc/dirs-rs"
+maintenance = { status = "actively-developed" }
+keywords    = ["xdg", "basedir", "app_dirs", "path", "folder"]
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["knownfolders", "objbase", "shlobj", "winbase", "winerror"] }

--- a/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/LICENSE-APACHE
+++ b/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/LICENSE-APACHE
@@ -1,0 +1,174 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.

--- a/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/LICENSE-MIT
+++ b/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/LICENSE-MIT
@@ -1,0 +1,19 @@
+Copyright (c) 2018 dirs-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/README.md
+++ b/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/README.md
@@ -1,0 +1,175 @@
+[![crates.io](https://img.shields.io/crates/v/dirs.svg)](https://crates.io/crates/dirs)
+[![API documentation](https://docs.rs/dirs/badge.svg)](https://docs.rs/dirs/)
+![actively developed](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
+[![TravisCI status](https://img.shields.io/travis/soc/dirs-rs/master.svg?label=Linux/macOS%20build)](https://travis-ci.org/soc/dirs-rs)
+[![AppVeyor status](https://img.shields.io/appveyor/ci/soc/dirs-rs/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/soc/dirs-rs/branch/master)
+![License: MIT/Apache-2.0](https://img.shields.io/badge/license-MIT%2FApache--2.0-orange.svg)
+
+# `dirs`
+
+## Introduction
+
+- a tiny low-level library with a minimal API
+- that provides the platform-specific, user-accessible locations
+- for retrieving and storing configuration, cache and other data
+- on Linux, Windows (≥ Vista), macOS and other platforms.
+
+The library provides the location of these directories by leveraging the mechanisms defined by
+- the [XDG base directory](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) and
+  the [XDG user directory](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/) specifications on Linux
+- the [Known Folder](https://msdn.microsoft.com/en-us/library/windows/desktop/dd378457.aspx) API on Windows
+- the [Standard Directories](https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW6)
+  guidelines on macOS
+
+## Platforms
+
+This library is written in Rust, and supports Linux, macOS and Windows.
+Other platforms are also supported; they use the Linux conventions.
+
+It's mid-level sister library, _directories_, is available for Rust ([directories-rs](https://github.com/soc/directories-rs))
+and on the JVM ([directories-jvm](https://github.com/soc/directories-jvm)).
+
+## Usage
+
+#### Dependency
+
+Add the library as a dependency to your project by inserting
+
+```toml
+dirs = "1.0"
+```
+
+into the `[dependencies]` section of your Cargo.toml file.
+
+#### Example
+
+Library run by user Alice:
+
+```rust
+extern crate dirs;
+
+dirs::home_dir();
+// Lin: Some(/home/alice)
+// Win: Some(C:\Users\Alice)
+// Mac: Some(/Users/Alice)
+
+dirs::audio_dir();
+// Lin: Some(/home/alice/Music)
+// Win: Some(C:\Users\Alice\Music)
+// Mac: Some(/Users/Alice/Music)
+
+dirs::config_dir();
+// Lin: Some(/home/alice/.config)
+// Win: Some(C:\Users\Alice\AppData\Roaming)
+// Mac: Some(/Users/Alice/Library/Preferences)
+
+dirs::executable_dir();
+// Lin: Some(/home/alice/.local/bin)
+// Win: None
+// Mac: None
+```
+
+## Design Goals
+
+- The _dirs_ library is a low-level crate designed to provide the paths to standard directories
+  as defined by operating systems rules or conventions. If your requirements are more complex,
+  e. g. computing cache, config, etc. paths for specific applications or projects, consider using
+  [directories](https://github.com/soc/directories-rs) instead.
+- This library does not create directories or check for their existence. The library only provides
+  information on what the path to a certain directory _should_ be. How this information is used is
+  a decision that developers need to make based on the requirements of each individual application.
+- This library is intentionally focused on providing information on user-writable directories only.
+  There is no discernible benefit in returning a path that points to a user-level, writable
+  directory on one operating system, but a system-level, read-only directory on another, that would
+  outweigh the confusion and unexpected failures such an approach would cause.
+  - `executable_dir` is specified to provide the path to a user-writable directory for binaries.<br/>
+    As such a directory only commonly exists on Linux, it returns `None` on macOS and Windows.
+  - `font_dir` is specified to provide the path to a user-writable directory for fonts.<br/>
+    As such a directory only exists on Linux and macOS, it returns `None` on Windows.
+  - `runtime_dir` is specified to provide the path to a directory for non-essential runtime data.
+    It is required that this directory is created when the user logs in, is only accessible by the
+    user itself, is deleted when the user logs out, and supports all filesystem features of the
+    operating system.<br/>
+    As such a directory only commonly exists on Linux, it returns `None` on macOS and Windows.
+
+## Features
+
+**If you want to compute the location of cache, config or data directories for your own application or project,
+use `ProjectDirs` of the [directories](https://github.com/soc/directories-rs) project instead.**
+
+| Function name    | Value on Linux                                                                                   | Value on Windows                  | Value on macOS                              |
+| ---------------- | ------------------------------------------------------------------------------------------------ | --------------------------------- | ------------------------------------------- |
+| `home_dir`       | `Some($HOME)`                                                                                    | `Some({FOLDERID_Profile})`        | `Some($HOME)`                               |
+| `cache_dir`      | `Some($XDG_CACHE_HOME)`         or `Some($HOME`/.cache`)`                                        | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Caches`)`              |
+| `config_dir`     | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`                                       | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Preferences`)`         |
+| `data_dir`       | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)` |
+| `data_local_dir` | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Application Support`)` |
+| `executable_dir` | `Some($XDG_BIN_HOME`/../bin`)`  or `Some($XDG_DATA_HOME`/../bin`)` or `Some($HOME`/.local/bin`)` | `None`                            | `None`                                      |
+| `runtime_dir`    | `Some($XDG_RUNTIME_DIR)`        or `None`                                                        | `None`                            | `None`                                      |
+| `audio_dir`      | `Some(XDG_MUSIC_DIR)`           or `None`                                                        | `Some({FOLDERID_Music})`          | `Some($HOME`/Music/`)`                      |
+| `desktop_dir`    | `Some(XDG_DESKTOP_DIR)`         or `None`                                                        | `Some({FOLDERID_Desktop})`        | `Some($HOME`/Desktop/`)`                    |
+| `document_dir`   | `Some(XDG_DOCUMENTS_DIR)`       or `None`                                                        | `Some({FOLDERID_Documents})`      | `Some($HOME`/Documents/`)`                  |
+| `download_dir`   | `Some(XDG_DOWNLOAD_DIR)`        or `None`                                                        | `Some({FOLDERID_Downloads})`      | `Some($HOME`/Downloads/`)`                  |
+| `font_dir`       | `Some($XDG_DATA_HOME`/fonts/`)` or `Some($HOME`/.local/share/fonts/`)`                           | `None`                            | `Some($HOME`/Library/Fonts/`)`              |
+| `picture_dir`    | `Some(XDG_PICTURES_DIR)`        or `None`                                                        | `Some({FOLDERID_Pictures})`       | `Some($HOME`/Pictures/`)`                   |
+| `public_dir`     | `Some(XDG_PUBLICSHARE_DIR)`     or `None`                                                        | `Some({FOLDERID_Public})`         | `Some($HOME`/Public/`)`                     |
+| `template_dir`   | `Some(XDG_TEMPLATES_DIR)`       or `None`                                                        | `Some({FOLDERID_Templates})`      | `None`                                      |
+| `video_dir`      | `Some(XDG_VIDEOS_DIR)`          or `None`                                                        | `Some({FOLDERID_Videos})`         | `Some($HOME`/Movies/`)`                     |
+
+## Comparison
+
+There are other crates in the Rust ecosystem that try similar or related things.
+Here is an overview of them, combined with ratings on properties that guided the design of this crate.
+
+Please take this table with a grain of salt: a different crate might very well be more suitable for your specific use case.
+(Of course _my_ crate achieves _my_ design goals better than other crates, which might have had different design goals.)
+
+| Library                                                   | Status         | Lin | Mac | Win |Base|User|Proj|Conv|
+| --------------------------------------------------------- | -------------- |:---:|:---:|:---:|:--:|:--:|:--:|:--:|
+| [app_dirs](https://crates.io/crates/app_dirs)             | Unmaintained   |  ✔  |  ✔  |  ✔  | 🞈  | ✖  | ✔  | ✖  |
+| [app_dirs2](https://crates.io/crates/app_dirs2)           | Maintained     |  ✔  |  ✔  |  ✔  | 🞈  | ✖  | ✔  | ✖  |
+| **dirs**                                                  | **Developed**  |  ✔  |  ✔  |  ✔  | ✔  | ✔  | ✖  | ✔  |
+| [directories](https://crates.io/crates/directories)       | Developed      |  ✔  |  ✔  |  ✔  | ✔  | ✔  | ✔  | ✔  |
+| [s_app_dir](https://crates.io/crates/s_app_dir)           | Unmaintained?  |  ✔  |  ✖  |  🞈  | ✖  | ✖  | 🞈  | ✖  |
+| [standard_paths](https://crates.io/crates/standard_paths) | Maintained     |  ✔  |  ✖  |  ✔  | ✔  | ✔  | ✔  | ✖  |
+| [xdg](https://crates.io/crates/xdg)                       | Maintained     |  ✔  |  ✖  |  ✖  | ✔  | ✖  | ✔  | 🞈  |
+| [xdg-basedir](https://crates.io/crates/xdg-basedir)       | Unmaintained?  |  ✔  |  ✖  |  ✖  | ✔   | ✖  | ✖  | 🞈  |
+| [xdg-rs](https://crates.io/crates/xdg-rs)                 | Obsolete       |  ✔  |  ✖  |  ✖  | ✔   | ✖  | ✖  | 🞈  |
+
+- Lin: Linux support
+- Mac: macOS support
+- Win: Windows support
+- Base: Supports [generic base directories](https://github.com/soc/directories-rs#basedirs)
+- User: Supports [user directories](https://github.com/soc/directories-rs#userdirs)
+- Proj: Supports [project-specific base directories](https://github.com/soc/directories-rs#projectdirs)
+- Conv: Follows naming conventions of the operating system it runs on
+
+## Build
+
+It's possible to cross-compile this library if the necessary toolchains are installed with rustup.
+This is helpful to ensure a change hasn't broken code on a different platform.
+
+The following commands will build this library on Linux, macOS and Windows:
+
+```
+cargo build --target=x86_64-unknown-linux-gnu
+cargo build --target=x86_64-apple-darwin
+cargo build --target=x86_64-pc-windows-gnu
+```
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0
+   ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license
+   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/src/lib.rs
+++ b/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/src/lib.rs
@@ -1,0 +1,264 @@
+//! The _dirs_ crate is
+//!
+//! - a tiny library with a minimal API (16 functions)
+//! - that provides the platform-specific, user-accessible locations
+//! - for finding and storing configuration, cache and other data
+//! - on Linux, Windows (≥ Vista) and macOS.
+//!
+//! The library provides the location of these directories by leveraging the mechanisms defined by
+//!
+//! - the [XDG base directory](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) and the [XDG user directory](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/) specifications on Linux,
+//! - the [Known Folder](https://msdn.microsoft.com/en-us/library/windows/desktop/bb776911(v=vs.85).aspx) system on Windows, and
+//! - the [Standard Directories](https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW6) on macOS.
+//!
+
+#![deny(missing_docs)]
+
+use std::path::PathBuf;
+
+#[cfg(target_os = "windows")]                                mod win;
+#[cfg(target_os = "macos")]                                  mod mac;
+#[cfg(not(any(target_os = "windows", target_os = "macos")))] mod lin;
+#[cfg(unix)]                                                 mod unix;
+
+#[cfg(target_os = "windows")]                                use win as sys;
+#[cfg(target_os = "macos")]                                  use mac as sys;
+#[cfg(not(any(target_os = "windows", target_os = "macos")))] use lin as sys;
+
+/// Returns the path to the user's home directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                | Example        |
+/// | ------- | -------------------- | -------------- |
+/// | Linux   | `$HOME`              | /home/alice    |
+/// | macOS   | `$HOME`              | /Users/Alice   |
+/// | Windows | `{FOLDERID_Profile}` | C:\Users\Alice |
+///
+/// ### Linux and macOS:
+///
+/// - Use `$HOME` if it is set and not empty.
+/// - If `$HOME` is not set or empty, then the function `getpwuid_r` is used to determine
+///   the home directory of the current user.
+/// - If `getpwuid_r` lacks an entry for the current user id or the home directory field is empty,
+///   then the function returns `None`.
+///
+/// ### Windows:
+///
+/// This function retrieves the user profile folder using `SHGetKnownFolderPath`.
+///
+/// All the examples on this page mentioning `$HOME` use this behavior.
+/// 
+/// _Note:_ This function's behavior differs from [`std::env::home_dir`],
+/// which works incorrectly on Linux, macOS and Windows.
+///
+/// [`std::env::home_dir`]: https://doc.rust-lang.org/std/env/fn.home_dir.html
+pub fn home_dir() -> Option<PathBuf> {
+    sys::home_dir()
+}
+/// Returns the path to the user's cache directory.
+/// 
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                               | Example                      |
+/// | ------- | ----------------------------------- | ---------------------------- |
+/// | Linux   | `$XDG_CACHE_HOME` or `$HOME`/.cache | /home/alice/.cache           |
+/// | macOS   | `$HOME`/Library/Caches              | /Users/Alice/Library/Caches  |
+/// | Windows | `{FOLDERID_LocalAppData}`           | C:\Users\Alice\AppData\Local |
+pub fn cache_dir() -> Option<PathBuf> {
+    sys::cache_dir()
+}
+/// Returns the path to the user's config directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                                 | Example                          |
+/// | ------- | ------------------------------------- | -------------------------------- |
+/// | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config              |
+/// | macOS   | `$HOME`/Library/Preferences           | /Users/Alice/Library/Preferences |
+/// | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming   |
+pub fn config_dir() -> Option<PathBuf> {
+    sys::config_dir()
+}
+/// Returns the path to the user's data directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                                    | Example                                  |
+/// | ------- | ---------------------------------------- | ---------------------------------------- |
+/// | Linux   | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/alice/.local/share                 |
+/// | macOS   | `$HOME`/Library/Application Support      | /Users/Alice/Library/Application Support |
+/// | Windows | `{FOLDERID_RoamingAppData}`              | C:\Users\Alice\AppData\Roaming           |
+pub fn data_dir() -> Option<PathBuf> {
+    sys::data_dir()
+}
+/// Returns the path to the user's local data directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                                    | Example                                  |
+/// | ------- | ---------------------------------------- | ---------------------------------------- |
+/// | Linux   | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/alice/.local/share                 |
+/// | macOS   | `$HOME`/Library/Application Support      | /Users/Alice/Library/Application Support |
+/// | Windows | `{FOLDERID_LocalAppData}`                | C:\Users\Alice\AppData\Local             |
+pub fn data_local_dir() -> Option<PathBuf> {
+    sys::data_local_dir()
+}
+/// Returns the path to the user's executable directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                                                            | Example                |
+/// | ------- | ---------------------------------------------------------------- | ---------------------- |
+/// | Linux   | `$XDG_BIN_HOME` or `$XDG_DATA_HOME`/../bin or `$HOME`/.local/bin | /home/alice/.local/bin |
+/// | macOS   | –                                                                | –                      |
+/// | Windows | –                                                                | –                      |
+pub fn executable_dir() -> Option<PathBuf> {
+    sys::executable_dir()
+}
+/// Returns the path to the user's runtime directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value              | Example         |
+/// | ------- | ------------------ | --------------- |
+/// | Linux   | `$XDG_RUNTIME_DIR` | /run/user/1001/ |
+/// | macOS   | –                  | –               |
+/// | Windows | –                  | –               |
+pub fn runtime_dir() -> Option<PathBuf> {
+    sys::runtime_dir()
+}
+
+/// Returns the path to the user's audio directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value              | Example              |
+/// | ------- | ------------------ | -------------------- |
+/// | Linux   | `XDG_MUSIC_DIR`    | /home/alice/Music    |
+/// | macOS   | `$HOME`/Music      | /Users/Alice/Music   |
+/// | Windows | `{FOLDERID_Music}` | C:\Users\Alice\Music |
+pub fn audio_dir() -> Option<PathBuf> {
+    sys::audio_dir()
+}
+/// Returns the path to the user's desktop directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                | Example                |
+/// | ------- | -------------------- | ---------------------- |
+/// | Linux   | `XDG_DESKTOP_DIR`    | /home/alice/Desktop    |
+/// | macOS   | `$HOME`/Desktop      | /Users/Alice/Desktop   |
+/// | Windows | `{FOLDERID_Desktop}` | C:\Users\Alice\Desktop |
+pub fn desktop_dir() -> Option<PathBuf> {
+    sys::desktop_dir()
+}
+/// Returns the path to the user's document directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                  | Example                  |
+/// | ------- | ---------------------- | ------------------------ |
+/// | Linux   | `XDG_DOCUMENTS_DIR`    | /home/alice/Documents    |
+/// | macOS   | `$HOME`/Documents      | /Users/Alice/Documents   |
+/// | Windows | `{FOLDERID_Documents}` | C:\Users\Alice\Documents |
+pub fn document_dir() -> Option<PathBuf> {
+    sys::document_dir()
+}
+/// Returns the path to the user's download directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                  | Example                  |
+/// | ------- | ---------------------- | ------------------------ |
+/// | Linux   | `XDG_DOWNLOAD_DIR`     | /home/alice/Downloads    |
+/// | macOS   | `$HOME`/Downloads      | /Users/Alice/Downloads   |
+/// | Windows | `{FOLDERID_Downloads}` | C:\Users\Alice\Downloads |
+pub fn download_dir() -> Option<PathBuf> {
+    sys::download_dir()
+}
+/// Returns the path to the user's font directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                                                | Example                        |
+/// | ------- | ---------------------------------------------------- | ------------------------------ |
+/// | Linux   | `$XDG_DATA_HOME`/fonts or `$HOME`/.local/share/fonts | /home/alice/.local/share/fonts |
+/// | macOS   | `$HOME/Library/Fonts`                                | /Users/Alice/Library/Fonts     |
+/// | Windows | –                                                    | –                              |
+pub fn font_dir() -> Option<PathBuf> {
+    sys::font_dir()
+}
+/// Returns the path to the user's picture directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                 | Example                 |
+/// | ------- | --------------------- | ----------------------- |
+/// | Linux   | `XDG_PICTURES_DIR`    | /home/alice/Pictures    |
+/// | macOS   | `$HOME`/Pictures      | /Users/Alice/Pictures   |
+/// | Windows | `{FOLDERID_Pictures}` | C:\Users\Alice\Pictures |
+pub fn picture_dir() -> Option<PathBuf> {
+    sys::picture_dir()
+}
+/// Returns the path to the user's public directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                 | Example             |
+/// | ------- | --------------------- | ------------------- |
+/// | Linux   | `XDG_PUBLICSHARE_DIR` | /home/alice/Public  |
+/// | macOS   | `$HOME`/Public        | /Users/Alice/Public |
+/// | Windows | `{FOLDERID_Public}`   | C:\Users\Public     |
+pub fn public_dir() -> Option<PathBuf> {
+    sys::public_dir()
+}
+/// Returns the path to the user's template directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value                  | Example                                                    |
+/// | ------- | ---------------------- | ---------------------------------------------------------- |
+/// | Linux   | `XDG_TEMPLATES_DIR`    | /home/alice/Templates                                      |
+/// | macOS   | –                      | –                                                          |
+/// | Windows | `{FOLDERID_Templates}` | C:\Users\Alice\AppData\Roaming\Microsoft\Windows\Templates |
+pub fn template_dir() -> Option<PathBuf> {
+    sys::template_dir()
+}
+
+/// Returns the path to the user's video directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// |Platform | Value               | Example               |
+/// | ------- | ------------------- | --------------------- |
+/// | Linux   | `XDG_VIDEOS_DIR`    | /home/alice/Videos    |
+/// | macOS   | `$HOME`/Movies      | /Users/Alice/Movies   |
+/// | Windows | `{FOLDERID_Videos}` | C:\Users\Alice\Videos |
+pub fn video_dir() -> Option<PathBuf> {
+    sys::video_dir()
+}
+
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_dirs() {
+        println!("home_dir:       {:?}", ::home_dir());
+        println!("cache_dir:      {:?}", ::cache_dir());
+        println!("config_dir:     {:?}", ::config_dir());
+        println!("data_dir:       {:?}", ::data_dir());
+        println!("data_local_dir: {:?}", ::data_local_dir());
+        println!("executable_dir: {:?}", ::executable_dir());
+        println!("runtime_dir:    {:?}", ::runtime_dir());
+        println!("audio_dir:      {:?}", ::audio_dir());
+        println!("home_dir:       {:?}", ::desktop_dir());
+        println!("cache_dir:      {:?}", ::document_dir());
+        println!("config_dir:     {:?}", ::download_dir());
+        println!("font_dir:       {:?}", ::font_dir());
+        println!("picture_dir:    {:?}", ::picture_dir());
+        println!("public_dir:     {:?}", ::public_dir());
+        println!("template_dir:   {:?}", ::template_dir());
+        println!("video_dir:      {:?}", ::video_dir());
+    }
+}

--- a/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/src/lin.rs
+++ b/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/src/lin.rs
@@ -1,0 +1,58 @@
+use std::env;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command;
+
+use unix;
+
+pub fn home_dir()       -> Option<PathBuf> { unix::home_dir() }
+pub fn cache_dir()      -> Option<PathBuf> { env::var_os("XDG_CACHE_HOME") .and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".cache"))) }
+pub fn config_dir()     -> Option<PathBuf> { env::var_os("XDG_CONFIG_HOME").and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".config"))) }
+pub fn data_dir()       -> Option<PathBuf> { env::var_os("XDG_DATA_HOME")  .and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".local/share"))) }
+pub fn data_local_dir() -> Option<PathBuf> { data_dir().clone() }
+pub fn runtime_dir()    -> Option<PathBuf> { env::var_os("XDG_RUNTIME_DIR").and_then(is_absolute_path) }
+pub fn executable_dir() -> Option<PathBuf> {
+    env::var_os("XDG_BIN_HOME").and_then(is_absolute_path).or_else(|| {
+        data_dir().map(|mut e| { e.pop(); e.push("bin"); e })
+    })
+}
+pub fn audio_dir()      -> Option<PathBuf> { run_xdg_user_dir_command("MUSIC") }
+pub fn desktop_dir()    -> Option<PathBuf> { run_xdg_user_dir_command("DESKTOP") }
+pub fn document_dir()   -> Option<PathBuf> { run_xdg_user_dir_command("DOCUMENTS") }
+pub fn download_dir()   -> Option<PathBuf> { run_xdg_user_dir_command("DOWNLOAD") }
+pub fn font_dir()       -> Option<PathBuf> { data_dir().map(|d| d.join("fonts")) }
+pub fn picture_dir()    -> Option<PathBuf> { run_xdg_user_dir_command("PICTURES") }
+pub fn public_dir()     -> Option<PathBuf> { run_xdg_user_dir_command("PUBLICSHARE") }
+pub fn template_dir()   -> Option<PathBuf> { run_xdg_user_dir_command("TEMPLATES") }
+pub fn video_dir()      -> Option<PathBuf> { run_xdg_user_dir_command("VIDEOS") }
+
+// we don't need to explicitly handle empty strings in the code above,
+// because an empty string is not considered to be a absolute path here.
+fn is_absolute_path(path: OsString) -> Option<PathBuf> {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn run_xdg_user_dir_command(arg: &str) -> Option<PathBuf> {
+    use std::os::unix::ffi::OsStringExt;
+    let mut out = match Command::new("xdg-user-dir").arg(arg).output() {
+    Ok(output) => output.stdout,
+        Err(_) => return None,
+    };
+    let out_len = out.len();
+    out.truncate(out_len - 1);
+    Some(PathBuf::from(OsString::from_vec(out)))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_file_user_dirs_exists() {
+        let user_dirs_file = ::config_dir().unwrap().join("user-dirs.dirs");
+        println!("{:?} exists: {:?}", user_dirs_file, user_dirs_file.exists());
+    }
+}

--- a/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/src/mac.rs
+++ b/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/src/mac.rs
@@ -1,0 +1,20 @@
+use std::path::PathBuf;
+
+use unix;
+
+pub fn home_dir()       -> Option<PathBuf> { unix::home_dir() }
+pub fn cache_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Caches")) }
+pub fn config_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Preferences")) }
+pub fn data_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Application Support")) }
+pub fn data_local_dir() -> Option<PathBuf> { data_dir() }
+pub fn executable_dir() -> Option<PathBuf> { None }
+pub fn runtime_dir()    -> Option<PathBuf> { None }
+pub fn audio_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Music")) }
+pub fn desktop_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Desktop")) }
+pub fn document_dir()   -> Option<PathBuf> { home_dir().map(|h| h.join("Documents")) }
+pub fn download_dir()   -> Option<PathBuf> { home_dir().map(|h| h.join("Downloads")) }
+pub fn font_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Fonts")) }
+pub fn picture_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Pictures")) }
+pub fn public_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Public")) }
+pub fn template_dir()   -> Option<PathBuf> { None }
+pub fn video_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Movies")) }

--- a/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/src/unix.rs
+++ b/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/src/unix.rs
@@ -1,0 +1,49 @@
+#![cfg(unix)]
+
+use std::env;
+use std::path::PathBuf;
+use std::mem;
+use std::ptr;
+use std::ffi::CStr;
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
+
+extern crate libc;
+
+// https://github.com/rust-lang/rust/blob/master/src/libstd/sys/unix/os.rs#L498
+pub fn home_dir() -> Option<PathBuf> {
+    return env::var_os("HOME").and_then(|h| { if h.is_empty() { None } else { Some(h) } } ).or_else(|| unsafe {
+        fallback()
+    }).map(PathBuf::from);
+
+    #[cfg(any(target_os = "android",
+              target_os = "ios",
+              target_os = "emscripten"))]
+    unsafe fn fallback() -> Option<OsString> { None }
+    #[cfg(not(any(target_os = "android",
+                  target_os = "ios",
+                  target_os = "emscripten")))]
+    unsafe fn fallback() -> Option<OsString> {
+        let amt = match libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) {
+            n if n < 0 => 512 as usize,
+            n => n as usize,
+        };
+        let mut buf = Vec::with_capacity(amt);
+        let mut passwd: libc::passwd = mem::zeroed();
+        let mut result = ptr::null_mut();
+        match libc::getpwuid_r(libc::getuid(), &mut passwd, buf.as_mut_ptr(),
+                               buf.capacity(), &mut result) {
+            0 if !result.is_null() => {
+                let ptr = passwd.pw_dir as *const _;
+                let bytes = CStr::from_ptr(ptr).to_bytes();
+                if bytes.is_empty() {
+                    None
+                } else {
+                    Some(OsStringExt::from_vec(bytes.to_vec()))
+                }
+            },
+            _ => None,
+        }
+    }
+}
+

--- a/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/src/win.rs
+++ b/rust_crates/registry/src/github.com-1ecc6299db9ec823/dirs-1.0.3/src/win.rs
@@ -1,0 +1,44 @@
+use std;
+use std::path::PathBuf;
+
+extern crate winapi;
+use self::winapi::shared::winerror;
+use self::winapi::um::knownfolders;
+use self::winapi::um::combaseapi;
+use self::winapi::um::shlobj;
+use self::winapi::um::shtypes;
+use self::winapi::um::winbase;
+use self::winapi::um::winnt;
+
+pub fn home_dir()       -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Profile) }
+pub fn data_dir()       -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_RoamingAppData) }
+pub fn data_local_dir() -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_LocalAppData) }
+pub fn cache_dir()      -> Option<PathBuf> { data_local_dir() }
+pub fn config_dir()     -> Option<PathBuf> { data_dir() }
+pub fn executable_dir() -> Option<PathBuf> { None }
+pub fn runtime_dir()    -> Option<PathBuf> { None }
+pub fn audio_dir()      -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Music) }
+pub fn desktop_dir()    -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Desktop) }
+pub fn document_dir()   -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Documents) }
+pub fn download_dir()   -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Downloads) }
+pub fn font_dir()       -> Option<PathBuf> { None }
+pub fn picture_dir()    -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Pictures) }
+pub fn public_dir()     -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Public) }
+pub fn template_dir()   -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Templates) }
+pub fn video_dir()      -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Videos) }
+
+fn known_folder(folder_id: shtypes::REFKNOWNFOLDERID) -> Option<PathBuf> {
+    unsafe {
+        let mut path_ptr: winnt::PWSTR = std::ptr::null_mut();
+        let result = shlobj::SHGetKnownFolderPath(folder_id, 0, std::ptr::null_mut(), &mut path_ptr);
+        if result == winerror::S_OK {
+            let len = winbase::lstrlenW(path_ptr) as usize;
+            let path = std::slice::from_raw_parts(path_ptr, len);
+            let ostr: std::ffi::OsString = std::os::windows::ffi::OsStringExt::from_wide(path);
+            combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
+            Some(PathBuf::from(ostr))
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
## FOR denoland/deno#747

Rust [recommends](https://doc.rust-lang.org/std/env/fn.home_dir.html) [`dirs`](https://crates.io/crates/dirs/1.0.3) crate since `std::env::home_dir` would be deprecated.

Related to denoland/deno#745

- [x] Add `dirs-1.0.3`