### PR TITLE
cherry-pick depot_tools 6a1d778 to fix macOS Cataliona issues

### DIFF
--- a/depot_tools/gsutil.vpython
+++ b/depot_tools/gsutil.vpython
@@ -44,7 +44,7 @@ wheel: <
 
 wheel: <
   name: "infra/python/wheels/asn1crypto-py2_py3"
-  version: "version:0.22.0"
+  version: "version:1.0.1"
 >
 
 wheel: <


### PR DESCRIPTION
Alternative to #53 to just cherry-pick `6a1d778` from `depot_tools` to fix broken `download_from_google_storage.py` on macOS Catalina, see https://github.com/denoland/deno/pull/3172 and  https://github.com/denoland/deno/issues/3153.
